### PR TITLE
Review Handlebars

### DIFF
--- a/app/inject/TemplateServiceProvider.java
+++ b/app/inject/TemplateServiceProvider.java
@@ -19,8 +19,6 @@ import static java.util.stream.Collectors.toList;
 
 class TemplateServiceProvider implements Provider<TemplateService> {
     private static final String CONFIG_TEMPLATE_LOADERS = "handlebars.templateLoaders";
-    private static final String CONFIG_FALLBACK_CONTEXTS = "handlebars.fallbackContexts";
-    private static final String CONFIG_CACHE_ENABLED = "handlebars.cache.enabled";
     private static final String CLASSPATH_TYPE = "classpath";
     private static final String FILE_TYPE = "file";
     private static final String TYPE_ATTR = "type";
@@ -40,12 +38,9 @@ class TemplateServiceProvider implements Provider<TemplateService> {
         if (templateLoaders.isEmpty()) {
             throw new SunriseInitializationException("No Handlebars template loaders found in configuration '" + CONFIG_TEMPLATE_LOADERS + "'");
         }
-        final List<TemplateLoader> fallbackContexts = initializeTemplateLoaders(CONFIG_FALLBACK_CONTEXTS);
-        final boolean cacheIsEnabled = configuration.getBoolean(CONFIG_CACHE_ENABLED, false);
-        Logger.debug("Provide HandlebarsTemplateService: template loaders [{}], cache enabled {}",
-                templateLoaders.stream().map(TemplateLoader::getPrefix).collect(joining(", ")),
-                cacheIsEnabled);
-        return HandlebarsTemplateService.of(templateLoaders, fallbackContexts, i18NResolver, cacheIsEnabled);
+        Logger.debug("Provide HandlebarsTemplateService: template loaders [{}]]",
+                templateLoaders.stream().map(TemplateLoader::getPrefix).collect(joining(", ")));
+        return HandlebarsTemplateService.of(templateLoaders, i18NResolver);
     }
 
     private List<TemplateLoader> initializeTemplateLoaders(final String configKey) {

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ lazy val commonSettings = testSettings ++ releaseSettings ++ Seq (
     "io.sphere.sdk.jvm" % "sphere-models" % sphereJvmSdkVersion,
     "io.sphere.sdk.jvm" % "sphere-play-2_4-java-client_2.10" % sphereJvmSdkVersion,
     "org.webjars" % "webjars-play_2.10" % "2.4.0-1",
-    "com.github.jknack" % "handlebars" % "2.2.3",
+    "com.github.jknack" % "handlebars" % "4.0.3",
     filters,
     "commons-beanutils" % "commons-beanutils" % "1.9.2",
     "commons-io" % "commons-io" % "2.4"

--- a/common/app/common/templates/HandlebarsTemplateService.java
+++ b/common/app/common/templates/HandlebarsTemplateService.java
@@ -1,40 +1,31 @@
 package common.templates;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
-import com.github.jknack.handlebars.ValueResolver;
-import com.github.jknack.handlebars.context.JavaBeanValueResolver;
-import com.github.jknack.handlebars.context.MapValueResolver;
-import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
+import com.github.jknack.handlebars.cache.HighConcurrencyTemplateCache;
 import com.github.jknack.handlebars.io.TemplateLoader;
 import common.controllers.PageData;
 import common.i18n.I18nResolver;
 import play.Logger;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.*;
+import java.util.List;
+import java.util.Locale;
 
 import static java.util.stream.Collectors.toList;
 
 public final class HandlebarsTemplateService implements TemplateService {
     private final Handlebars handlebars;
-    private final List<TemplateLoader> fallbackContexts;
-    private final boolean cacheEnabled;
 
-    private HandlebarsTemplateService(final Handlebars handlebars, final List<TemplateLoader> fallbackContexts,
-                                      final boolean cacheEnabled) {
+    private HandlebarsTemplateService(final Handlebars handlebars) {
         this.handlebars = handlebars;
-        this.fallbackContexts = fallbackContexts;
-        this.cacheEnabled = cacheEnabled;
     }
 
     @Override
     public String render(final String templateName, final PageData pageData, final List<Locale> locales) {
         final Template template = compileTemplate(templateName);
-        final Context context = buildContext(pageData, templateName);
+        final Context context = Context.newContext(pageData);;
         context.data("locales", locales.stream().map(Locale::toLanguageTag).collect(toList()));
         try {
             Logger.debug("Rendering template " + templateName);
@@ -44,13 +35,15 @@ public final class HandlebarsTemplateService implements TemplateService {
         }
     }
 
-    public static TemplateService of(final List<TemplateLoader> templateLoaders, final List<TemplateLoader> fallbackContexts,
-                                     final I18nResolver i18NResolver, final boolean cacheEnabled) {
+    public static TemplateService of(final List<TemplateLoader> templateLoaders, final I18nResolver i18NResolver) {
         final TemplateLoader[] loaders = templateLoaders.toArray(new TemplateLoader[templateLoaders.size()]);
-        final Handlebars handlebars = new Handlebars().with(loaders).infiniteLoops(true);
+        final Handlebars handlebars = new Handlebars()
+                .with(loaders)
+                .with(new HighConcurrencyTemplateCache())
+                .infiniteLoops(true);
         handlebars.registerHelper("i18n", new CustomI18nHelper(i18NResolver));
         handlebars.registerHelper("json", new HandlebarsJsonHelper<>());
-        return new HandlebarsTemplateService(handlebars, fallbackContexts, cacheEnabled);
+        return new HandlebarsTemplateService(handlebars);
     }
 
     private Template compileTemplate(final String templateName) {
@@ -59,43 +52,5 @@ public final class HandlebarsTemplateService implements TemplateService {
         } catch (IOException e) {
             throw new TemplateNotFoundException("Could not find the default template", e);
         }
-    }
-
-    private Context buildContext(final PageData pageData, final String templateName) {
-        Context.Builder builder = Context.newBuilder(pageData)
-                .resolver(valueResolver(), MapValueResolver.INSTANCE);
-        for (final TemplateLoader fallbackContext : fallbackContexts) {
-            final Optional<Map<String, ?>> map = buildFallbackContext(fallbackContext, templateName);
-            if (map.isPresent()) {
-                builder = builder.combine(map.get());
-            }
-        }
-        return builder.build();
-    }
-
-    private ValueResolver valueResolver() {
-        return cacheEnabled ? JavaBeanValueResolver.INSTANCE : NonCachedJavaBeanValueResolver.INSTANCE;
-    }
-
-    private Optional<Map<String, ?>> buildFallbackContext(final TemplateLoader fallbackLoader, final String templateName) {
-        return getResource(fallbackLoader, templateName).map(stream -> {
-            try {
-                return new ObjectMapper().readValue(stream, HashMap.class);
-            } catch (IOException e) {
-                Logger.error("Could not read fallback context", e);
-                return null;
-            }
-        });
-    }
-
-    private Optional<InputStream> getResource(final TemplateLoader fallbackLoader, final String templateName) {
-        final InputStream resource;
-        if (fallbackLoader instanceof ClassPathTemplateLoader) {
-            final String path = fallbackLoader.resolve(templateName).replaceAll("^/?(.*)\\.hbs$", "$1.json");
-            resource = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
-        } else {
-            throw new RuntimeException("Invalid fallback context type, only classpath supported");
-        }
-        return Optional.ofNullable(resource);
     }
 }

--- a/common/app/common/templates/HandlebarsTemplateService.java
+++ b/common/app/common/templates/HandlebarsTemplateService.java
@@ -25,7 +25,7 @@ public final class HandlebarsTemplateService implements TemplateService {
     @Override
     public String render(final String templateName, final PageData pageData, final List<Locale> locales) {
         final Template template = compileTemplate(templateName);
-        final Context context = Context.newContext(pageData);;
+        final Context context = Context.newContext(pageData);
         context.data("locales", locales.stream().map(Locale::toLanguageTag).collect(toList()));
         try {
             Logger.debug("Rendering template " + templateName);

--- a/common/test/common/templates/CustomI18nHelperTest.java
+++ b/common/test/common/templates/CustomI18nHelperTest.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Locale.ENGLISH;
 import static java.util.Locale.GERMAN;
@@ -75,7 +74,7 @@ public class CustomI18nHelperTest {
 
     private static void testTemplate(final String templateName, final Locale locale, final Map<String, String> i18nMap,
                                      final Consumer<String> test) {
-        final TemplateService templateService = HandlebarsTemplateService.of(singletonList(DEFAULT_LOADER), emptyList(), i18nResolver(i18nMap), false);
+        final TemplateService templateService = HandlebarsTemplateService.of(singletonList(DEFAULT_LOADER), i18nResolver(i18nMap));
         final String html = renderTemplate(templateName, templateService, locale);
         test.accept(html);
     }

--- a/common/test/common/templates/HandlebarsTemplateTest.java
+++ b/common/test/common/templates/HandlebarsTemplateTest.java
@@ -63,39 +63,12 @@ public class HandlebarsTemplateTest {
                 .isInstanceOf(TemplateNotFoundException.class);
     }
 
-    @Test
-    public void usesFallbackContextWhenMissingData() throws Exception {
-        testTemplate("template", handlebarsWithFallbackContext(DEFAULT_LOADER), html ->
-                assertThat(html)
-                        .contains("<title>foo</title>")
-                        .contains("<h1>bar</h1>")
-                        .contains("<h2>fallback unknown</h2>")
-                        .contains("<p>default partial</p>")
-                        .contains("<ul><li>fallback foo</li><li>fallback bar</li></ul>")
-        );
-    }
-
-    @Test
-    public void failsSilentlyWhenFallbackContextNotFound() throws Exception {
-        testTemplate("template", handlebarsWithFallbackContext(WRONG_LOADER), html ->
-                assertThat(html).contains("<title>foo</title>")
-                        .contains("<h1>bar</h1>")
-                        .contains("<h2></h2>")
-                        .contains("<p>default partial</p>")
-                        .contains("<ul></ul>")
-        );
-    }
-
     private static TemplateService defaultHandlebars() {
-        return HandlebarsTemplateService.of(singletonList(DEFAULT_LOADER), emptyList(), I18N_MESSAGES, false);
+        return HandlebarsTemplateService.of(singletonList(DEFAULT_LOADER), I18N_MESSAGES);
     }
 
     private static TemplateService handlebarsWithOverride() {
-        return HandlebarsTemplateService.of(asList(OVERRIDE_LOADER, DEFAULT_LOADER), emptyList(), I18N_MESSAGES, false);
-    }
-
-    private static TemplateService handlebarsWithFallbackContext(final TemplateLoader fallbackContextLoader) {
-        return HandlebarsTemplateService.of(singletonList(DEFAULT_LOADER), singletonList(fallbackContextLoader), I18N_MESSAGES, false);
+        return HandlebarsTemplateService.of(asList(OVERRIDE_LOADER, DEFAULT_LOADER), I18N_MESSAGES);
     }
 
     private static void testTemplate(final String templateName, final TemplateService templateService, final Consumer<String> test) {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -31,14 +31,9 @@ application.i18n.resolverLoaders = [
 productData.enabledAttributes = ["size"]
 
 # handlebars config
-handlebars.cache.enabled = false
 handlebars.templateLoaders = [
   {"type":"classpath", "path":"/templates"},
   {"type":"classpath", "path":"/META-INF/resources/webjars/templates"}
-]
-handlebars.fallbackContexts = [
-#  the JSON file from Sunrise Design
-#  {"type":"classpath", "path":"/META-INF/resources/webjars/templates"}
 ]
 
 # common config

--- a/conf/prod.conf
+++ b/conf/prod.conf
@@ -3,8 +3,6 @@ include "application"
 application.setup.enabled = false
 application.metrics.enabled = false
 
-handlebars.cache.enabled = true
-
 ctp.projectKey = ${CTP_PROJECT_KEY}
 ctp.clientId = ${CTP_CLIENT_ID}
 ctp.clientSecret = ${CTP_CLIENT_SECRET}


### PR DESCRIPTION
- Update to latest handlebars version 4.0.3.
- Remove cache option: now it is initialized with a TemplateCache and it does not seem to be affected by Play's hot-reloading.
- Remove fallback context option: it only supported JSON and was a bit hacky, plus I cannot find any real use to be enabled as configuration.