### PR TITLE
Enable config env vars, closes #245, closes #21

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,16 +6,79 @@
   "keywords": ["commercetools", "ecommerce", "shopping"],
   "env": {
     "CTP_PROJECT_KEY": {
-      "description": "The project key for your commercetools platform project.",
-      "required": true
+      "description": "The project key for your commercetools platform project."
     },
     "CTP_CLIENT_ID": {
-      "description": "The client ID of your commercetools platform project.",
-      "required": true
+      "description": "The client ID of your commercetools platform project."
     },
     "CTP_CLIENT_SECRET": {
-      "description": "The client secret of your commercetools platform project.",
-      "required": true
+      "description": "The client secret of your commercetools platform project."
+    },
+
+    "SELECTABLE_ATTRIBUTES": {
+      "description": "The product attributes that allow to identify and select a product variant in your project. Enter the attribute keys separated by commas."
+    },
+
+    "APPLICATION_SECRET": {
+      "description": "The secret key is used to secure cryptographics functions. Anyone that can get access to the application secret will be able to generate any session they please, effectively allowing them to log in to your system as any user they please. If you deploy your application to several instances be sure to use the same key.",
+      "generator": "secret"
+    },
+
+    "COUNTRIES": {
+      "description": "The application uses the countries defined in your project. If you want to replace them, enter the list of countries as ISO country codes (e.g. DE). Default country first.",
+      "required": false
+    },
+    "CURRENCIES": {
+      "description": "The application uses the currencies defined in your project. If you want to replace them, enter the list of currencies as ISO currency codes (e.g. EUR). Default currency first.",
+      "required": false
+    },
+    "LANGUAGES": {
+      "description": "The application uses the languages defined in your project. If you want to replace them, enter the list of languages as language tags (e.g. en-UK). Default language first.",
+      "required": false
+    },
+
+    "SALES_CATEGORY": {
+      "description": "The sales category in your project. Enter the category external ID.",
+      "required": false
+    },
+    "NEW_CATEGORY": {
+      "description": "The category containing the new products in your project. Enter the category external ID.",
+      "required": false
+    },
+
+    "HOME_SUGGESTIONS_CATEGORIES": {
+      "description": "The categories where to obtain the products shown in the home page suggestions. Enter the category external IDs separated by commas.",
+      "required": false
+    },
+
+    "HOME_SUGGESTIONS_SIZE": {
+      "description": "The amount of products displayed in the home page suggestions.",
+      "required": false
+    },
+    "PRODUCT_SUGGESTIONS_SIZE": {
+      "description": "The amount of products displayed for a product's suggestions.",
+      "required": false
+    },
+
+    "SEARCH_FIELD": {
+      "description": "Field in the URL query string containing the searched term.",
+      "value": "q"
+    },
+    "SORT_FIELD": {
+      "description": "Field in the URL query string containing the sorting criteria.",
+      "value": "sort"
+    },
+    "PRODUCTS_PER_PAGE_FIELD": {
+      "description": "Field in the URL query string containing the amount of products per page.",
+      "value": "display"
+    },
+    "PRODUCTS_PER_PAGE_OPTIONS": {
+      "description": "Available options to select the amount of products per page. Enter the values separated by commas.",
+      "value": "24, 48"
+    },
+    "PRODUCTS_PER_PAGE_DEFAULT": {
+      "description": "The selected amount of products per page by default.",
+      "value": "24"
     }
   }
 }

--- a/app/inject/SunriseApplicationLoader.java
+++ b/app/inject/SunriseApplicationLoader.java
@@ -1,0 +1,18 @@
+package inject;
+
+import common.utils.SunriseConfiguration;
+import play.Configuration;
+import play.inject.guice.GuiceApplicationBuilder;
+import play.inject.guice.GuiceApplicationLoader;
+
+import static play.inject.Bindings.bind;
+
+public class SunriseApplicationLoader extends GuiceApplicationLoader {
+
+    @Override
+    public GuiceApplicationBuilder builder(final Context context) {
+        return super.builder(context).overrides(
+                bind(Configuration.class).toInstance(new SunriseConfiguration(context.initialConfiguration()))
+        );
+    }
+}

--- a/common/app/common/utils/SunriseConfiguration.java
+++ b/common/app/common/utils/SunriseConfiguration.java
@@ -1,0 +1,111 @@
+package common.utils;
+
+import com.typesafe.config.ConfigException;
+import play.Configuration;
+import play.api.PlayException;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+public class SunriseConfiguration extends Configuration {
+
+    public SunriseConfiguration(final Configuration configuration) {
+        super(configuration.underlying());
+    }
+
+    @Override
+    @Nullable
+    public List<String> getStringList(final String key) {
+        try {
+            return super.getStringList(key);
+        } catch (PlayException e) {
+            return recoverAndParseList(key, this::parseStringList, e).orElse(null);
+        }
+    }
+
+    @Override
+    public List<String> getStringList(final String key, final List<String> defaultList) {
+        try {
+            return super.getStringList(key, defaultList);
+        } catch (PlayException e) {
+            return recoverAndParseList(key, this::parseStringList, e).orElse(defaultList);
+        }
+    }
+
+    @Nullable
+    @Override
+    public List<Boolean> getBooleanList(final String key) {
+        try {
+            return super.getBooleanList(key);
+        } catch (PlayException e) {
+            return recoverAndParseList(key, this::parseBooleanList, e).orElse(null);
+        }
+    }
+
+    @Override
+    public List<Boolean> getBooleanList(final String key, final List<Boolean> defaultList) {
+        try {
+            return super.getBooleanList(key, defaultList);
+        } catch (PlayException e) {
+            return recoverAndParseList(key, this::parseBooleanList, e).orElse(defaultList);
+        }
+    }
+
+    @Nullable
+    @Override
+    public List<Integer> getIntList(final String key) {
+        try {
+            return super.getIntList(key);
+        } catch (PlayException e) {
+            return recoverAndParseList(key, this::parseIntList, e).orElse(null);
+        }
+    }
+
+    @Override
+    public List<Integer> getIntList(final String key, final List<Integer> defaultList) {
+        try {
+            return super.getIntList(key, defaultList);
+        } catch (PlayException e) {
+            return recoverAndParseList(key, this::parseIntList, e).orElse(defaultList);
+        }
+    }
+
+    private <T> Optional<List<T>> recoverAndParseList(final String key, final Function<String, List<T>> parser,
+                                                      final PlayException e) {
+        if (e.getCause() instanceof ConfigException.WrongType) {
+            return Optional.ofNullable(getString(key))
+                    .map(parser::apply)
+                    .filter(value -> !value.isEmpty());
+        } else {
+            throw e;
+        }
+    }
+
+    private List<Integer> parseIntList(final String value) {
+        return parseList(value)
+                .map(Integer::parseInt)
+                .collect(toList());
+    }
+
+    private List<Boolean> parseBooleanList(final String value) {
+        return parseList(value)
+                .map(Boolean::parseBoolean)
+                .collect(toList());
+    }
+
+    private List<String> parseStringList(final String value) {
+        return parseList(value).collect(toList());
+    }
+
+    private static Stream<String> parseList(final String value) {
+        return Arrays.asList(value.split(",")).stream()
+                .map(String::trim)
+                .filter(v -> !v.isEmpty());
+    }
+}

--- a/common/test/common/controllers/WithSunriseApplication.java
+++ b/common/test/common/controllers/WithSunriseApplication.java
@@ -79,6 +79,7 @@ public abstract class WithSunriseApplication {
 
     protected Configuration baseConfiguration() {
         final Map<String, Object> additionalSettings = new HashMap<>();
+        additionalSettings.put("application.metrics.enabled", false);
         additionalSettings.put("application.settingsWidget.enabled", false);
         additionalSettings.put("play.crypto.secret", RandomStringUtils.randomAlphanumeric(15));
         return new Configuration(additionalSettings);

--- a/common/test/common/templates/HandlebarsTemplateTest.java
+++ b/common/test/common/templates/HandlebarsTemplateTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class HandlebarsTemplateTest {
     private static final TemplateLoader DEFAULT_LOADER = new ClassPathTemplateLoader("/templates");
     private static final TemplateLoader OVERRIDE_LOADER = new ClassPathTemplateLoader("/templates/override");
-    private static final TemplateLoader WRONG_LOADER = new ClassPathTemplateLoader("/templates/wrong");
     private static final I18nResolver I18N_MESSAGES = ((locale, bundle, key, args) -> Optional.empty());
     private static final List<Locale> LOCALES = emptyList();
     private static final PageData SOME_PAGE_DATA = new TestablePageData();

--- a/common/test/common/utils/SunriseConfigurationTest.java
+++ b/common/test/common/utils/SunriseConfigurationTest.java
@@ -1,0 +1,101 @@
+package common.utils;
+
+import org.junit.Test;
+import play.Configuration;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SunriseConfigurationTest {
+    private static final String CONFIG_KEY = "key";
+
+    @Test
+    public void ignoresEmptyValues() throws Exception {
+        testWithConfig(CONFIG_KEY, "foo, ,baz", config ->
+                assertThat(config.getStringList(CONFIG_KEY)).containsExactly("foo", "baz"));
+    }
+
+    @Test
+    public void returnsNullWithEmptyString() throws Exception {
+        testWithConfig(CONFIG_KEY, " ", config ->
+                assertThat(config.getStringList(CONFIG_KEY)).isNull());
+    }
+
+    @Test
+    public void returnsNullWithJustComma() throws Exception {
+        testWithConfig(CONFIG_KEY, ",", config ->
+                assertThat(config.getStringList(CONFIG_KEY)).isNull());
+    }
+
+    @Test
+    public void parsesStringList() throws Exception {
+        testWithConfig(CONFIG_KEY, "foo, bar, baz", config ->
+                assertThat(config.getStringList(CONFIG_KEY)).containsExactly("foo", "bar", "baz"));
+    }
+
+    @Test
+    public void parsesStringListWithDefault() throws Exception {
+        final List<String> defaultList = asList("foo", "qux");
+        testWithConfig(CONFIG_KEY, "foo, bar, baz", config ->
+                assertThat(config.getStringList(CONFIG_KEY, defaultList)).containsExactly("foo", "bar", "baz"));
+    }
+
+    @Test
+    public void returnsDefaultStringListWithEmptyString() throws Exception {
+        final List<String> defaultList = asList("foo", "qux");
+        testWithConfig(CONFIG_KEY, "", config ->
+                assertThat(config.getStringList(CONFIG_KEY, defaultList)).containsExactlyElementsOf(defaultList));
+    }
+
+    @Test
+    public void parsesBooleanList() throws Exception {
+        testWithConfig(CONFIG_KEY, "true, false, baz", config ->
+                assertThat(config.getBooleanList(CONFIG_KEY)).containsExactly(true, false, false));
+    }
+
+    @Test
+    public void parsesBooleanListWithDefault() throws Exception {
+        final List<Boolean> defaultList = asList(false, true);
+        testWithConfig(CONFIG_KEY, "true, false, baz", config ->
+                assertThat(config.getBooleanList(CONFIG_KEY, defaultList)).containsExactly(true, false, false));
+    }
+
+    @Test
+    public void returnsDefaultBooleanListWithEmptyString() throws Exception {
+        final List<Boolean> defaultList = asList(false, true);
+        testWithConfig(CONFIG_KEY, "", config ->
+                assertThat(config.getBooleanList(CONFIG_KEY, defaultList)).containsExactlyElementsOf(defaultList));
+    }
+
+    @Test
+    public void parsesIntList() throws Exception {
+        testWithConfig(CONFIG_KEY, "0, -76, 105", config ->
+                assertThat(config.getIntList(CONFIG_KEY)).containsExactly(0, -76, 105));
+    }
+
+    @Test
+    public void parsesIntListWithDefault() throws Exception {
+        final List<Integer> defaultList = asList(6, 20);
+        testWithConfig(CONFIG_KEY, "0, -76, 105", config ->
+                assertThat(config.getIntList(CONFIG_KEY, defaultList)).containsExactly(0, -76, 105));
+    }
+
+    @Test
+    public void returnsDefaultIntListWithEmptyString() throws Exception {
+        final List<Integer> defaultList = asList(6, 20);
+        testWithConfig(CONFIG_KEY, "", config ->
+                assertThat(config.getIntList(CONFIG_KEY, defaultList)).containsExactlyElementsOf(defaultList));
+    }
+
+    private static void testWithConfig(final String key, final String value, final Consumer<SunriseConfiguration> test) {
+        final Map<String, Object> settings = new HashMap<>();
+        settings.put(key, value);
+        final SunriseConfiguration config = new SunriseConfiguration(new Configuration(settings));
+        test.accept(config);
+    }
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -5,7 +5,8 @@
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-play.crypto.secret="TsLWj4[^1N<7nrI/>EkyPDTO[dnh<7_R[j;cN0:lGK6Mm`0048C@3PK]4KR6HobLhu"
+play.crypto.secret="changeme"
+play.crypto.secret=${?APPLICATION_SECRET}
 
 # Injection configuration
 # ~~~~~
@@ -26,10 +27,9 @@ application.countries = ${?COUNTRIES}
 application.currencies = ${?CURRENCIES}
 
 #application.i18n.languages = ["en", "de", "es"] # uncomment to override languages from CTP project, default first
-application.i18n.languages = ${?I18N_LANGUAGES}
+application.i18n.languages = ${?LANGUAGES}
 
 application.i18n.bundles = ["translations", "home", "catalog", "checkout"]
-application.i18n.bundles = ${?I18N_BUNDLES}
 
 application.i18n.resolverLoaders = [
   {"type": "yaml", "path": "locales"},
@@ -37,7 +37,7 @@ application.i18n.resolverLoaders = [
 ]
 
 productData.enabledAttributes = ["size"]
-productData.enabledAttributes = ${?ENABLED_ATTRIBUTES}
+productData.enabledAttributes = ${?SELECTABLE_ATTRIBUTES}
 
 # handlebars config
 handlebars.templateLoaders = [
@@ -47,37 +47,37 @@ handlebars.templateLoaders = [
 
 # common config
 common.saleCategoryExternalId = "6"
-common.saleCategoryExternalId = ${?SALE_CATEGORY_EXTERNAL_ID}
+common.saleCategoryExternalId = ${?SALES_CATEGORY}
 
 common.newCategoryExternalId = "1"
-common.newCategoryExternalId = ${?NEW_CATEGORY_EXTERNAL_ID}
+common.newCategoryExternalId = ${?NEW_CATEGORY}
 
 
 # home page config
 home.suggestions.externalId = ["29", "37", "22", "28"]
-home.suggestions.externalId = ${?HOME_SUGGESTIONS_CATEGORIES_EXT_ID}
+home.suggestions.externalId = ${?HOME_SUGGESTIONS_CATEGORIES}
 
 home.suggestions.count = 4
 home.suggestions.count = ${?HOME_SUGGESTIONS_SIZE}
 
 # product overview page config
 pop.fulltext.key = "q"
-pop.fulltext.key = ${?POP_SEARCH_KEY}
+pop.fulltext.key = ${?SEARCH_FIELD}
 
 pop.pageSize.key = "display"
-pop.pageSize.key = ${?POP_PAGE_SIZE_KEY}
+pop.pageSize.key = ${?PRODUCTS_PER_PAGE_FIELD}
 
 pop.pageSize.options = [24, 48]
-pop.pageSize.options = ${?POP_PAGE_SIZE_OPTIONS}
+pop.pageSize.options = ${?PRODUCTS_PER_PAGE_OPTIONS}
 
 pop.pageSize.default = 24
-pop.pageSize.default = ${?POP_PAGE_SIZE_DEFAULT}
+pop.pageSize.default = ${?PRODUCTS_PER_PAGE_DEFAULT}
 
 pop.sort.key = "sort"
-pop.sort.key = ${?POP_SORT_KEY}
+pop.sort.key = ${?SORT_FIELD}
 
 pop.pagination.displayedPages = 6
-pop.pagination.displayedPages = ${?POP_PAGINATION_DISPLAYED_PAGES}
+pop.pagination.displayedPages = ${?PAGINATION_DISPLAYED_PAGES}
 
 pop.facet.size = ["one Size","XXS","XS","S","M","L","XL","XXL","XXXL","34","34.5","35","35.5","36","36.5","37","37.5",
   "38","38.5","39","39.5","40","40.5","41","41.5","42","42.5","43","43.5","44","44.5","45","45.5","46","46.5","47",
@@ -86,7 +86,7 @@ pop.facet.size = ["one Size","XXS","XS","S","M","L","XL","XXL","XXXL","34","34.5
 
 # product detail page config
 pdp.productSuggestions.count = 4
-pdp.productSuggestions.count = ${?PDP_SUGGESTIONS_SIZE}
+pdp.productSuggestions.count = ${?PRODUCT_SUGGESTIONS_SIZE}
 
 
 # checkout pages config

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -6,10 +6,10 @@
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
 play.crypto.secret="TsLWj4[^1N<7nrI/>EkyPDTO[dnh<7_R[j;cN0:lGK6Mm`0048C@3PK]4KR6HobLhu"
-play.crypto.secret=${?APPLICATION_SECRET}
 
-# The enabled modules
+# Injection configuration
 # ~~~~~
+play.application.loader = "inject.SunriseApplicationLoader"
 play.modules.enabled += "inject.CtpClientProductionModule"
 play.modules.enabled += "inject.CtpModelsProductionModule"
 play.modules.enabled += "inject.ApplicationProductionModule"
@@ -20,15 +20,24 @@ application.metrics.enabled = true
 application.setup.enabled = true
 
 #application.countries = ["DE", "US", "GB", "AT", "CH"] # uncomment to override countries from CTP project, default first
-#application.currencies = ["EUR"] # uncomment to override currencies from CTP project, default first
+application.countries = ${?COUNTRIES}
+
+#application.currencies = ["EUR", "USD"] # uncomment to override currencies from CTP project, default first
+application.currencies = ${?CURRENCIES}
+
 #application.i18n.languages = ["en", "de", "es"] # uncomment to override languages from CTP project, default first
+application.i18n.languages = ${?I18N_LANGUAGES}
+
 application.i18n.bundles = ["translations", "home", "catalog", "checkout"]
+application.i18n.bundles = ${?I18N_BUNDLES}
+
 application.i18n.resolverLoaders = [
   {"type": "yaml", "path": "locales"},
   {"type": "yaml", "path": "META-INF/resources/webjars/locales"}
 ]
 
 productData.enabledAttributes = ["size"]
+productData.enabledAttributes = ${?ENABLED_ATTRIBUTES}
 
 # handlebars config
 handlebars.templateLoaders = [
@@ -38,19 +47,38 @@ handlebars.templateLoaders = [
 
 # common config
 common.saleCategoryExternalId = "6"
+common.saleCategoryExternalId = ${?SALE_CATEGORY_EXTERNAL_ID}
+
 common.newCategoryExternalId = "1"
+common.newCategoryExternalId = ${?NEW_CATEGORY_EXTERNAL_ID}
+
 
 # home page config
 home.suggestions.externalId = ["29", "37", "22", "28"]
+home.suggestions.externalId = ${?HOME_SUGGESTIONS_CATEGORIES_EXT_ID}
+
 home.suggestions.count = 4
+home.suggestions.count = ${?HOME_SUGGESTIONS_SIZE}
 
 # product overview page config
 pop.fulltext.key = "q"
+pop.fulltext.key = ${?POP_SEARCH_KEY}
+
 pop.pageSize.key = "display"
+pop.pageSize.key = ${?POP_PAGE_SIZE_KEY}
+
 pop.pageSize.options = [24, 48]
+pop.pageSize.options = ${?POP_PAGE_SIZE_OPTIONS}
+
 pop.pageSize.default = 24
+pop.pageSize.default = ${?POP_PAGE_SIZE_DEFAULT}
+
 pop.sort.key = "sort"
+pop.sort.key = ${?POP_SORT_KEY}
+
 pop.pagination.displayedPages = 6
+pop.pagination.displayedPages = ${?POP_PAGINATION_DISPLAYED_PAGES}
+
 pop.facet.size = ["one Size","XXS","XS","S","M","L","XL","XXL","XXXL","34","34.5","35","35.5","36","36.5","37","37.5",
   "38","38.5","39","39.5","40","40.5","41","41.5","42","42.5","43","43.5","44","44.5","45","45.5","46","46.5","47",
   "47.5","70","75","80","85","90","95","100","105","110","115","120"]
@@ -58,6 +86,8 @@ pop.facet.size = ["one Size","XXS","XS","S","M","L","XL","XXL","XXXL","34","34.5
 
 # product detail page config
 pdp.productSuggestions.count = 4
+pdp.productSuggestions.count = ${?PDP_SUGGESTIONS_SIZE}
+
 
 # checkout pages config
 checkout.allowedTitles = [

--- a/conf/prod.conf
+++ b/conf/prod.conf
@@ -1,5 +1,7 @@
 include "application"
 
+play.crypto.secret=${?APPLICATION_SECRET}
+
 application.setup.enabled = false
 application.metrics.enabled = false
 

--- a/conf/prod.conf
+++ b/conf/prod.conf
@@ -1,7 +1,5 @@
 include "application"
 
-play.crypto.secret=${?APPLICATION_SECRET}
-
 application.setup.enabled = false
 application.metrics.enabled = false
 


### PR DESCRIPTION
- Injected custom configuration class that allows to parse some comma-separated text as a list. This allows to configure easily from Heroku without forcing to change the `application.conf` way of providing lists ( @schleichardt check please)
- Enable all interesting configuration via Heroku.
- Force to set application secret and auto-generate it for Heroku ( @schleichardt check too).